### PR TITLE
Update tree-sitter to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,11 +528,11 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-edit"
-version = "0.3.0"
-source = "git+https://github.com/wetneb/tree-sitter-edit.git?branch=bump_tree_sitter_to_0.25#2c464a1a9407f3b3aa669ee01712caa3514be79f"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a48463b62ae47dbcf230e38a1c2173fbe1c4b20c84030fbd17fbb5124aa05266"
 dependencies = [
  "tree-sitter",
- "tree-sitter-traversal2",
 ]
 
 [[package]]
@@ -559,15 +559,6 @@ checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
 dependencies = [
  "cc",
  "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-traversal2"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba902d00ce3c8229bf933e0a5972609657d39c5cfc09d9b3431baa0f6e18c16"
-dependencies = [
- "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -69,11 +69,11 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -139,6 +139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -160,6 +172,16 @@ name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -193,9 +215,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "nu-ansi-term"
@@ -300,9 +322,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -311,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ryu"
@@ -347,6 +381,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -363,10 +398,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -467,61 +514,70 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-edit"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed3213ee656e99748eca539913b5c90df3d52618d9a1714e0935013955c8031"
+source = "git+https://github.com/wetneb/tree-sitter-edit.git?branch=bump_tree_sitter_to_0.25#2c464a1a9407f3b3aa669ee01712caa3514be79f"
 dependencies = [
  "tree-sitter",
- "tree-sitter-traversal",
+ "tree-sitter-traversal2",
 ]
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.20.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d1463af5be7052171161db7cfe45c7621ed959ae533972ab47a09b1ed70ec0"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.4"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-traversal"
-version = "0.1.2"
+name = "tree-sitter-traversal2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8a158225e4a4d8505f071340bba9edd109b23f01b70540dccb7c799868f307"
+checksum = "fba902d00ce3c8229bf933e0a5972609657d39c5cfc09d9b3431baa0f6e18c16"
 dependencies = [
  "tree-sitter",
 ]
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.20.5"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8bc1d2c24276a48ef097a71b56888ac9db63717e8f8d0b324668a27fd619670"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/crates/tree-splicer-javascript/Cargo.toml
+++ b/crates/tree-splicer-javascript/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/langston-barrett/tree-splicer"
 [dependencies]
 anyhow = "1"
 tree-splicer = { version = "0.6.0", path = "../tree-splicer", features = ["cli"] }
-tree-sitter-javascript = "0.20"
+tree-sitter-javascript = "0.23"

--- a/crates/tree-splicer-javascript/src/main.rs
+++ b/crates/tree-splicer-javascript/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 fn main() -> Result<()> {
     tree_splicer::cli::main(
-        tree_sitter_javascript::language(),
+        tree_sitter_javascript::LANGUAGE.into(),
         tree_sitter_javascript::NODE_TYPES,
     )
 }

--- a/crates/tree-splicer-rust/Cargo.toml
+++ b/crates/tree-splicer-rust/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/langston-barrett/tree-splicer"
 [dependencies]
 anyhow = "1"
 tree-splicer = { version = "0.6.0", path = "../tree-splicer", features = ["cli"] }
-tree-sitter-rust = "0.20"
+tree-sitter-rust = "0.24"

--- a/crates/tree-splicer-rust/src/main.rs
+++ b/crates/tree-splicer-rust/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    tree_splicer::cli::main(tree_sitter_rust::language(), tree_sitter_rust::NODE_TYPES)
+    tree_splicer::cli::main(tree_sitter_rust::LANGUAGE.into(), tree_sitter_rust::NODE_TYPES)
 }

--- a/crates/tree-splicer-rust/src/main.rs
+++ b/crates/tree-splicer-rust/src/main.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
 
 fn main() -> Result<()> {
-    tree_splicer::cli::main(tree_sitter_rust::LANGUAGE.into(), tree_sitter_rust::NODE_TYPES)
+    tree_splicer::cli::main(
+        tree_sitter_rust::LANGUAGE.into(),
+        tree_sitter_rust::NODE_TYPES,
+    )
 }

--- a/crates/tree-splicer-typescript/Cargo.toml
+++ b/crates/tree-splicer-typescript/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/langston-barrett/tree-splicer"
 [dependencies]
 anyhow = "1"
 tree-splicer = { version = "0.6.0", path = "../tree-splicer", features = ["cli"] }
-tree-sitter-typescript = "0.20"
+tree-sitter-typescript = "0.23"

--- a/crates/tree-splicer-typescript/src/main.rs
+++ b/crates/tree-splicer-typescript/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 
 fn main() -> Result<()> {
     tree_splicer::cli::main(
-        tree_sitter_typescript::language_typescript(),
+        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
         tree_sitter_typescript::TYPESCRIPT_NODE_TYPES,
     )
 }

--- a/crates/tree-splicer/Cargo.toml
+++ b/crates/tree-splicer/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"], optional = true }
 tree-sitter = "0.25"
-tree-sitter-edit = { git = "https://github.com/wetneb/tree-sitter-edit.git", branch = "bump_tree_sitter_to_0.25" }
+tree-sitter-edit = "0.4"
 
 [features]
 default = []

--- a/crates/tree-splicer/Cargo.toml
+++ b/crates/tree-splicer/Cargo.toml
@@ -22,8 +22,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"], optional = true }
-tree-sitter = "0.20"
-tree-sitter-edit = "0.3"
+tree-sitter = "0.25"
+tree-sitter-edit = { git = "https://github.com/wetneb/tree-sitter-edit.git", branch = "bump_tree_sitter_to_0.25" }
 
 [features]
 default = []

--- a/crates/tree-splicer/src/cli.rs
+++ b/crates/tree-splicer/src/cli.rs
@@ -112,10 +112,10 @@ fn read_file(file: &str) -> Result<String> {
     fs::read_to_string(file).with_context(|| format!("Failed to read file {}", file))
 }
 
-fn parse(language: tree_sitter::Language, code: &str) -> Result<tree_sitter::Tree> {
+fn parse(language: &tree_sitter::Language, code: &str) -> Result<tree_sitter::Tree> {
     let mut parser = tree_sitter::Parser::new();
     parser
-        .set_language(language)
+        .set_language(language.into())
         .context("Failed to set tree-sitter parser language")?;
     parser.parse(code, None).context("Failed to parse code")
 }
@@ -159,13 +159,13 @@ pub fn main(language: tree_sitter::Language, node_types_json_str: &'static str) 
         if f == "-" {
             let path = "<stdin>".to_string();
             let s = stdin_string()?;
-            let tree = parse(language, &s)?;
+            let tree = parse(&language, &s)?;
             handle_parse_errors(&path, &tree, &args.on_parse_error);
             files.insert(path, (s.into_bytes(), tree));
         } else {
             let path = f;
             let s = read_file(&path)?;
-            let tree = parse(language, &s)?;
+            let tree = parse(&language, &s)?;
             handle_parse_errors(&path, &tree, &args.on_parse_error);
             files.insert(path, (s.into_bytes(), tree));
         }

--- a/crates/tree-splicer/src/cli.rs
+++ b/crates/tree-splicer/src/cli.rs
@@ -109,13 +109,13 @@ pub struct Args {
 }
 
 fn read_file(file: &str) -> Result<String> {
-    fs::read_to_string(file).with_context(|| format!("Failed to read file {}", file))
+    fs::read_to_string(file).with_context(|| format!("Failed to read file {file}"))
 }
 
 fn parse(language: &tree_sitter::Language, code: &str) -> Result<tree_sitter::Tree> {
     let mut parser = tree_sitter::Parser::new();
     parser
-        .set_language(language.into())
+        .set_language(language)
         .context("Failed to set tree-sitter parser language")?;
     parser.parse(code, None).context("Failed to parse code")
 }

--- a/crates/tree-splicer/src/cli/formatter.rs
+++ b/crates/tree-splicer/src/cli/formatter.rs
@@ -39,7 +39,7 @@ where
             if field.name() == "message" {
                 // TODO(lb): Pad level to 5 places
                 // TODO(lb): Don't print all the danged fields
-                write!(&mut writer, "[{}] ", style.paint(format!("{}", level)))?;
+                write!(&mut writer, "[{}] ", style.paint(format!("{level}")))?;
                 ctx.field_format().format_fields(writer.by_ref(), event)?;
             }
         }

--- a/crates/tree-splicer/src/splice.rs
+++ b/crates/tree-splicer/src/splice.rs
@@ -63,7 +63,7 @@ impl<'a> Branches<'a> {
     }
 }
 
-fn parse(language: Language, code: &str) -> tree_sitter::Tree {
+fn parse(language: &Language, code: &str) -> tree_sitter::Tree {
     let mut parser = tree_sitter::Parser::new();
     parser
         .set_language(language)
@@ -281,7 +281,7 @@ impl<'a> Splicer<'a> {
                 let mut result = Vec::with_capacity(usize::try_from(sz).unwrap_or_default());
                 tree_sitter_edit::render(&mut result, &tree, text.as_slice(), &edits).ok()?;
                 text = result.clone();
-                tree = parse(self.language, &String::from_utf8_lossy(text.as_slice()));
+                tree = parse(&self.language, &String::from_utf8_lossy(text.as_slice()));
                 edits = Edits::default();
             }
             if sized_out {


### PR DESCRIPTION
This upgrades to tree-sitter 0.25 and switches to my fork of the Rust grammar (as the upstream repository unfortunately isn't actively maintained).

This is a draft because it depends on https://github.com/langston-barrett/tree-sitter-edit/pull/28 being merged and released first.

Closes #146.